### PR TITLE
Use absolute path to logcat

### DIFF
--- a/logcat.el
+++ b/logcat.el
@@ -1233,10 +1233,7 @@ is incomplete, return nil."
          (adb-logcat-base-subarg "/system/bin/logcat -B '*:V'"))
     (if (string-equal adb-major-version "1")
         adb-logcat-base-subarg
-      (format "rcmd %s" adb-logcat-base-subarg)
-      )
-    )
-  )
+      (format "rcmd %s" adb-logcat-base-subarg))))
 
 (defun logcat--start-process (exe extra-arguments handle-log-record)
   (let ((cmdline (concat "exec "

--- a/logcat.el
+++ b/logcat.el
@@ -1230,7 +1230,7 @@ is incomplete, return nil."
          (adb-major-version (nth-value 0 version-list))
          (adb-minor-version (nth-value 1 version-list))
          (adb-patch-version (nth-value 2 version-list))
-         (adb-logcat-base-subarg "logcat -B '*:V'"))
+         (adb-logcat-base-subarg "/system/bin/logcat -B '*:V'"))
     (if (string-equal adb-major-version "1")
         adb-logcat-base-subarg
       (format "rcmd %s" adb-logcat-base-subarg)


### PR DESCRIPTION
On my android-24 stock emulator, `fb-adb rcmd logcat` gives:
```
fb-adb stub: execvpe("logcat"): Invalid argument
```
Some debugging later, it seems like it doesn't use the system path, so referring to it as /system/bin/logcat works.